### PR TITLE
Prepping UI and Better Pixel Art Resizing

### DIFF
--- a/main.html
+++ b/main.html
@@ -3,6 +3,7 @@
   <head>
   </head>
   <body>
+      <div id="render" style="width: calc(100% - 20px); height: calc((100vw - 20px) * 0.5625);"></div>
       <script src="bundle.js"></script>
   </body>
 </html>

--- a/src/bootstrap.js
+++ b/src/bootstrap.js
@@ -3,11 +3,15 @@ import { Howl as G_HOWL } from "howler";
 import * as G_PIXI from "pixi.js";
 import { G_LOGGER } from "./logger.js";
 
+// Render options
+G_PIXI.settings.SCALE_MODE = G_PIXI.SCALE_MODES.NEAREST;
+
 // Load application window
 // Create the application helper and add its render target to the page
-// TODO: Dynamic height adjustment
-const G_PIXI_APP = new G_PIXI.Application({ width: 640, height: 360});
-document.body.appendChild(G_PIXI_APP.view);
+let targetDOM = document.getElementById("render");
+let targetSize = {resizeTo: targetDOM, antialias: false, autoDensity: true};
+const G_PIXI_APP = new G_PIXI.Application(targetSize);
+targetDOM.appendChild(G_PIXI_APP.view);
 
 export {
     G_HOWL,

--- a/src/constants.js
+++ b/src/constants.js
@@ -18,8 +18,18 @@ const ASSETS = {
     "player": "temp_player.png"
 }
 
+// Setup play field constant scaling
+// Set the game's playfield to support auto-scaling
+// Think of this as max design. Any lower and pixels get down sized
+// any higher and pixels get up-scaled.
+const PLAY_AREA = {
+    width: 1280,
+    height:720
+}
+
 export {
     DEV_MODE,
+    PLAY_AREA,
     BUILD_ASSET_FOLDER,
     SCENES,
     ENTITIES,

--- a/src/entity/player.js
+++ b/src/entity/player.js
@@ -1,6 +1,7 @@
 import { Entity } from "./entity.js";
 import { playerBlueprint } from "./blueprints.js";
 import { G_PIXI_APP } from "../bootstrap.js";
+import { PLAY_AREA } from "../constants.js";
 
 class Player extends Entity  {
 
@@ -21,8 +22,20 @@ class Player extends Entity  {
     }
 
     movement(elapsed, curPos, player, enemies, space) {
-        let newX = Math.max(this.sprite.width/2, Math.min(G_PIXI_APP.screen.width - this.sprite.width / 2, curPos[0] + this.maxSpeed * this.dirX));
-        let newY = Math.max(this.sprite.height/2, Math.min(G_PIXI_APP.screen.height - this.sprite.height / 2, curPos[1] + this.maxSpeed * this.dirY));
+        let newX = Math.max(
+            this.sprite.width/2,
+            Math.min(
+                PLAY_AREA.width - this.sprite.width / 2,
+                curPos[0] + this.maxSpeed * this.dirX
+            )
+        );
+        let newY = Math.max(
+            this.sprite.height/2,
+            Math.min(
+                PLAY_AREA.height - this.sprite.height / 2,
+                curPos[1] + this.maxSpeed * this.dirY
+            )
+        );
         return new this.helpers.Pixi.Point(newX, newY);
     }
 

--- a/src/game.js
+++ b/src/game.js
@@ -4,25 +4,55 @@ import {G_PIXI_APP, G_HOWL, G_PIXI} from "./bootstrap.js";
 // engine
 import AssetManager from "./assets.js";
 import {G_LOGGER, getLevel, setLevel} from "./logger.js";
-import {SCENES, BUILD_ASSET_FOLDER, ASSETS} from "./constants.js";
+import {SCENES, BUILD_ASSET_FOLDER, ASSETS, PLAY_AREA} from "./constants.js";
 
 // STD
 const path = require("path");
 
 class Game {
+    // Bounded to event listener
+    resize(width, height) {
+        this.rootNode.scale.x = width / this.playArea.width;
+        this.rootNode.scale.y = height / this.playArea.height;
+    }
+
     constructor() {
+        // Game level constants binding
         this.scenes = SCENES;
         this.app = G_PIXI_APP
-        this.rootNode = G_PIXI_APP.stage
-        G_LOGGER.debug(G_HOWL);
         this.howler = G_HOWL;
         this.pixi = G_PIXI;
+
+        // Asset management
         this.assetManager = new AssetManager(
             this.pixi,
             BUILD_ASSET_FOLDER,
             ASSETS
         );
+
+        // Scene management
         this.currentScene = null;
+
+        // Virtual screen
+        this.playArea = PLAY_AREA;
+
+        let container = new G_PIXI.Container();
+        container.width = this.playArea.width;
+        container.height = this.playArea.height;
+        container.x = 0;
+        container.y = 0;
+        this.rootNode = container;
+
+        // Force a resize before binding to render
+        const { width, height } = G_PIXI_APP.screen;
+        this.resize(width, height);
+        G_PIXI_APP.stage.addChild(this.rootNode);
+
+        G_PIXI_APP.renderer.on("resize", (width, height) => {
+            G_LOGGER.log(width);
+            G_LOGGER.log(height);
+            this.resize(width, height);
+        });
     }
 
     //! Start the game


### PR DESCRIPTION
## Changes
- Adds `PLAY_AREA` constant. Use this as the "bounds" to the game instead of real screen size.
- Game now scales to window size. Our target artwork should target `PLAY_AREA` which is 1280x720 a 16:9 ration.
- Added a root container to do the auto scaling. So any examples that originally used WINDOW size should now use the virtual window defined by the resolution in `PLAY_AREA`
- Enabled nearest neighbor scaling instead and turned-off anti aliasing for our pixel art.